### PR TITLE
Change obsolete `name` attribute to `id`

### DIFF
--- a/src/pages/users.md
+++ b/src/pages/users.md
@@ -110,7 +110,7 @@ notable, e.g. be packaged in multiple (unrelated) distributions of GNU/Linux.
     * [Vertica Extension Packages](https://github.com/vertica/Vertica-Extension-Packages) — User Defined Extensions to the Vertica Analytic Database (see [`web_package/src/UriExtractor.cpp`](https://github.com/vertica/Vertica-Extension-Packages/blob/master/web_package/src/UriExtractor.cpp))
 
 
-# <a name="hardware"></a> Hardware
+# <a id="hardware"></a> Hardware
 
 * [hisense Smart TV Series 5](https://github.com/opensource-hisense/SmartTV-Series5/blob/master/source/uriparser/uriparser_external/UriGlue.c)
 * [hisense Smart TV Series 7](https://github.com/opensource-hisense/SmartTV-Series7/blob/master/Opensource%20Software/uriparser/uriparser_external/UriGlue.c)


### PR DESCRIPTION
This fixes an error in the W3C validator:
https://validator.w3.org/nu/?doc=https%3A%2F%2Furiparser.github.io%2Fdoc%2Fusers%2F